### PR TITLE
Fix typo in dynamic style object

### DIFF
--- a/apps/website/docs/learn/04-styling-components.md
+++ b/apps/website/docs/learn/04-styling-components.md
@@ -108,7 +108,7 @@ import { css, html } from 'react-strict-dom';
 
 const styles = css.create({
   size: (height: number, width: number) => ({
-    height * 0.9,
+    height: height * 0.9,
     width
   })
 });


### PR DESCRIPTION
The dynamic style object must be a valid style object which gets returned from the function.

The current value is not a valid object:
```
{
    height * 0.9,
    width
}
```

So, converting it to a valid style object:
```
{
    height: height * 0.9,
    width
}
```